### PR TITLE
Show version in settings page

### DIFF
--- a/crates/server/src/routes/admin_ui/pages/settings.rs
+++ b/crates/server/src/routes/admin_ui/pages/settings.rs
@@ -24,6 +24,7 @@ pub struct SettingsPage {
     pub csrf_token: String,
     pub providers: Vec<OidcProviderSummary>,
     pub providers_json: String,
+    pub version: &'static str,
 }
 
 /// GET /settings — render the settings page.
@@ -57,5 +58,6 @@ pub async fn settings_page(State(state): State<AppState>, request: Request) -> R
         csrf_token: csrf.0,
         providers,
         providers_json,
+        version: env!("CARGO_PKG_VERSION"),
     })
 }

--- a/crates/server/templates/pages/settings.html
+++ b/crates/server/templates/pages/settings.html
@@ -175,6 +175,17 @@
     </div>
     {% endif %}
 
+    <!-- Section: About -->
+    <h3 class="settings-section-header">About</h3>
+    <div class="card mb-6">
+        <div class="d-flex justify-between items-center">
+            <div>
+                <h3>Agent Cordon</h3>
+                <p class="text-sm mt-2 settings-desc">Version {{ version }}</p>
+            </div>
+        </div>
+    </div>
+
     <!-- Delete Provider Modal -->
     <div x-show="deleteProviderModal" x-cloak x-transition.opacity.duration.150ms class="modal-overlay" @click.self="deleteProviderModal = false" @keydown.escape.window="deleteProviderModal && (deleteProviderModal = false)">
         <div class="modal">


### PR DESCRIPTION
## Summary

- Adds `version: &'static str` field to `SettingsPage` struct, populated from `env!("CARGO_PKG_VERSION")` at compile time
- Adds an **About** section card at the bottom of the Settings page displaying the running version

## Test plan

- [x] Navigate to `/settings` and verify an "About" section appears at the bottom with the current version (e.g. `0.1.2`)
- [x] Bump the version in `Cargo.toml`, rebuild, and confirm the displayed version updates accordingly

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)