### PR TITLE
Add OAuth2 client credentials UI and Entra ID template

### DIFF
--- a/crates/server/src/routes/admin_api/credential_templates.rs
+++ b/crates/server/src/routes/admin_api/credential_templates.rs
@@ -34,6 +34,10 @@ pub struct CredentialTemplate {
     pub description: String,
     pub tags: Vec<String>,
     pub sort_order: u32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub oauth2_token_endpoint: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub oauth2_scopes: Option<String>,
 }
 
 #[derive(Embed)]

--- a/crates/server/templates/pages/credentials/new.html
+++ b/crates/server/templates/pages/credentials/new.html
@@ -63,12 +63,15 @@
 
                 <!-- Generic secret value (non-AWS) -->
                 <div class="form-group" x-show="form.credentialType !== 'aws'">
-                    <label for="cred-secret">Secret value <span class="required">*</span></label>
+                    <label for="cred-secret">
+                        <span x-text="form.credentialType === 'oauth2_client_credentials' ? 'Client Secret' : 'Secret value'"></span>
+                        <span class="required">*</span>
+                    </label>
                     <div class="secret-wrapper">
                         <input id="cred-secret" x-model="form.secretValue"
                                :type="form.showSecret ? 'text' : 'password'"
                                class="form-input"
-                               placeholder="API key or token">
+                               :placeholder="form.credentialType === 'oauth2_client_credentials' ? 'Paste your client secret' : 'API key or token'">
                         <button type="button" class="secret-toggle" @click="form.showSecret = !form.showSecret"
                                 x-text="form.showSecret ? 'Hide' : 'Show'"></button>
                     </div>
@@ -76,6 +79,27 @@
                     <div x-show="looksLikeAwsKey" class="alert alert-warning">
                         This looks like an AWS Access Key ID. AWS credentials need the <strong>AWS credential type</strong> for SigV4 signing to work correctly.
                         <button type="button" class="btn btn-sm btn-primary" @click="applyTemplate('aws')">Switch to AWS template</button>
+                    </div>
+                </div>
+
+                <!-- OAuth2 client credentials fields -->
+                <div x-show="form.credentialType === 'oauth2_client_credentials'" class="oauth2-fields">
+                    <div class="form-group">
+                        <label for="cred-oauth2-client-id">Client ID <span class="required">*</span></label>
+                        <input id="cred-oauth2-client-id" x-model="form.oauth2ClientId" type="text"
+                               class="form-input mono" placeholder="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" autocomplete="off">
+                    </div>
+                    <div class="form-group">
+                        <label for="cred-oauth2-token-endpoint">Token Endpoint <span class="required">*</span></label>
+                        <input id="cred-oauth2-token-endpoint" x-model="form.oauth2TokenEndpoint" type="text"
+                               class="form-input mono" placeholder="https://login.microsoftonline.com/{tenant}/oauth2/v2.0/token" autocomplete="off">
+                        <div class="form-hint">Must be HTTPS. The token endpoint where AgentCordon will acquire access tokens.</div>
+                    </div>
+                    <div class="form-group">
+                        <label for="cred-oauth2-scopes">Scopes</label>
+                        <input id="cred-oauth2-scopes" x-model="form.oauth2Scopes" type="text"
+                               class="form-input" placeholder="https://graph.microsoft.com/.default" autocomplete="off">
+                        <div class="form-hint">Space-delimited. For Entra ID use <code>{resource}/.default</code>.</div>
                     </div>
                 </div>
 
@@ -175,6 +199,9 @@ function credentialNewPage() {
             awsAccessKeyId: '',
             awsSecretAccessKey: '',
             showAwsSecret: false,
+            oauth2ClientId: '',
+            oauth2TokenEndpoint: '',
+            oauth2Scopes: '',
             tags: [],
             tagInput: '',
             allowedUrlPattern: '',
@@ -200,7 +227,9 @@ function credentialNewPage() {
                             credentialType: t.credential_type || 'generic',
                             allowedUrlPattern: t.allowed_url_pattern || '',
                             description: t.description || '',
-                            tags: t.tags || []
+                            tags: t.tags || [],
+                            oauth2_token_endpoint: t.oauth2_token_endpoint || '',
+                            oauth2_scopes: t.oauth2_scopes || ''
                         };
                     });
                     this.credentialTemplates = obj;
@@ -218,6 +247,9 @@ function credentialNewPage() {
                 this.form.allowedUrlPattern = '';
                 this.form.description = '';
                 this.form.tags = [];
+                this.form.oauth2ClientId = '';
+                this.form.oauth2TokenEndpoint = '';
+                this.form.oauth2Scopes = '';
                 return;
             }
             var tpl = this.credentialTemplates[key];
@@ -228,6 +260,8 @@ function credentialNewPage() {
                 this.form.allowedUrlPattern = tpl.allowedUrlPattern;
                 this.form.description = tpl.description;
                 this.form.tags = [...tpl.tags];
+                this.form.oauth2TokenEndpoint = tpl.oauth2_token_endpoint || '';
+                this.form.oauth2Scopes = tpl.oauth2_scopes || '';
             }
         },
 
@@ -271,6 +305,11 @@ function credentialNewPage() {
                 body.aws_secret_access_key = this.form.awsSecretAccessKey;
             } else {
                 body.secret_value = this.form.secretValue;
+            }
+            if (this.form.credentialType === 'oauth2_client_credentials') {
+                body.oauth2_client_id = this.form.oauth2ClientId;
+                body.oauth2_token_endpoint = this.form.oauth2TokenEndpoint;
+                if (this.form.oauth2Scopes) body.oauth2_scopes = this.form.oauth2Scopes;
             }
             try {
                 var resp = await fetch('/api/v1/credentials', {

--- a/data/credential-templates/entra-id.json
+++ b/data/credential-templates/entra-id.json
@@ -1,0 +1,15 @@
+{
+  "key": "entra-id",
+  "name": "Microsoft Entra ID",
+  "service": "login.microsoftonline.com",
+  "credential_type": "oauth2_client_credentials",
+  "auth_type": "oauth2_client_credentials",
+  "header": "Authorization",
+  "allowed_url_pattern": "https://*.microsoft.com/*",
+  "fields": ["secret_value", "oauth2_client_id", "oauth2_token_endpoint", "oauth2_scopes"],
+  "description": "OAuth2 client credentials for Microsoft Entra ID (Azure AD). Tokens are acquired automatically and injected as a Bearer header.",
+  "tags": ["azure", "microsoft", "entra", "oauth2"],
+  "sort_order": 65,
+  "oauth2_token_endpoint": "https://login.microsoftonline.com/{tenant_id}/oauth2/v2.0/token",
+  "oauth2_scopes": "https://graph.microsoft.com/.default"
+}


### PR DESCRIPTION
## Summary

- Adds `client_id`, `token_endpoint`, and `scopes` input fields to the credential creation form for the `oauth2_client_credentials` type
- Dynamically relabels the secret field as "Client Secret" when the OAuth2 type is selected
- Adds optional `oauth2_token_endpoint` and `oauth2_scopes` fields to `CredentialTemplate` so templates can pre-fill them
- Adds a **Microsoft Entra ID** credential template pre-filled with the token endpoint pattern and `https://graph.microsoft.com/.default` scope

## Test plan

- [ ] Select the Entra ID template — form should switch to `oauth2_client_credentials` type with token endpoint and scopes pre-filled
- [ ] Replace `{tenant_id}` in the token endpoint, enter a client ID and client secret, submit — credential should be created
- [ ] Verify the created credential has `oauth2_client_id`, `oauth2_token_endpoint`, and `oauth2_scopes` stored in metadata
- [ ] Proxy a request through the credential and confirm a Bearer token is injected

🤖 Generated with [Claude Code](https://claude.com/claude-code)