### PR TITLE
Fix GLIBC_2.38 runtime error by upgrading base image to debian:trixie…

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/core", "crates/server", "crates/gateway"]
 
 [workspace.package]
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 license = "MIT"
 homepage = "https://agentcordon.dev"

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ RUN touch crates/core/src/lib.rs crates/server/src/main.rs
 RUN cargo build --release --bin agent-cordon-server
 
 # Runtime stage
-FROM debian:bookworm-slim
+FROM debian:trixie-slim
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,4 +1,4 @@
-FROM debian:bookworm-slim
+FROM debian:trixie-slim
 
 ARG TARGETARCH
 

--- a/crates/gateway/Cargo.toml
+++ b/crates/gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentcordon"
-version = "0.1.2"
+version = "0.1.4"
 edition = "2021"
 
 [[bin]]


### PR DESCRIPTION
…-slim

The release workflow builds on ubuntu-latest (glibc 2.39) but the Docker runtime used debian:bookworm-slim (glibc 2.36), causing the server binary to fail at startup. Bump runtime base to trixie-slim (glibc 2.40).

Bumps version to 0.1.4.