### PR TITLE
feat(workspaces): view/delete OAuth consent grants per workspace (#10)

### DIFF
--- a/crates/core/src/domain/audit.rs
+++ b/crates/core/src/domain/audit.rs
@@ -102,6 +102,10 @@ pub enum AuditEventType {
     DeviceCodeDenied,
     DeviceCodeExpired,
 
+    // OAuth2 consent management (issue #10)
+    /// Admin or self revoked an OAuth consent grant; cascades to token revocation.
+    ConsentRevoked,
+
     // MCP
     McpServerRegistered,
     McpServerUpdated,

--- a/crates/core/src/policy/actions.rs
+++ b/crates/core/src/policy/actions.rs
@@ -24,6 +24,8 @@ pub const MCP_TOOL_CALL: &str = "mcp_tool_call";
 pub const MCP_LIST_TOOLS: &str = "mcp_list_tools";
 pub const REGISTER_WORKSPACE: &str = "register_workspace";
 pub const MANAGE_TAGS: &str = "manage_tags";
+/// Issue #10 — manage OAuth consent grants (view/delete).
+pub const MANAGE_CONSENTS: &str = "manage_consents";
 
 // Backward-compat aliases (removed in later phases)
 pub const MANAGE_AGENTS: &str = MANAGE_WORKSPACES;

--- a/crates/core/src/policy/cedar/entity_builders.rs
+++ b/crates/core/src/policy/cedar/entity_builders.rs
@@ -99,6 +99,10 @@ impl CedarPolicyEngine {
 
         let attrs: HashMap<String, RestrictedExpression> = HashMap::from([
             (
+                "id".to_string(),
+                RestrictedExpression::new_string(user.id.0.to_string()),
+            ),
+            (
                 "name".to_string(),
                 RestrictedExpression::new_string(user.username.clone()),
             ),
@@ -379,6 +383,14 @@ impl CedarPolicyEngine {
             .map_err(|e| PolicyError::Evaluation(format!("context: {e}"))),
             actions::MANAGE_TAGS => Context::from_pairs(vec![
                 ("tag_value".to_string(), string_expr(claim_keys::TAG_VALUE)),
+                ("timestamp".to_string(), timestamp_expr),
+            ])
+            .map_err(|e| PolicyError::Evaluation(format!("context: {e}"))),
+            actions::MANAGE_CONSENTS => Context::from_pairs(vec![
+                (
+                    "consent_user_id".to_string(),
+                    string_expr(claim_keys::CONSENT_USER_ID),
+                ),
                 ("timestamp".to_string(), timestamp_expr),
             ])
             .map_err(|e| PolicyError::Evaluation(format!("context: {e}"))),

--- a/crates/core/src/policy/mod.rs
+++ b/crates/core/src/policy/mod.rs
@@ -160,6 +160,10 @@ pub mod claim_keys {
     /// Optional justification (String) provided by the workspace for
     /// audit/compliance.
     pub const JUSTIFICATION: &str = "justification";
+    /// User ID (String, hyphenated UUID) of a consent grant's owner. Set on
+    /// `manage_consents` requests so policies can self-permit the granter.
+    /// Issue #10.
+    pub const CONSENT_USER_ID: &str = "consent_user_id";
 }
 
 /// Trait for policy engines that evaluate authorization decisions.

--- a/crates/core/src/storage/postgres/oauth.rs
+++ b/crates/core/src/storage/postgres/oauth.rs
@@ -138,4 +138,21 @@ impl OAuthStore for PostgresStore {
             "oauth: postgres not yet implemented".into(),
         ))
     }
+    async fn list_oauth_consents_for_client(
+        &self,
+        _client_id: &str,
+    ) -> Result<Vec<OAuthConsent>, StoreError> {
+        Err(StoreError::Database(
+            "oauth: postgres not yet implemented".into(),
+        ))
+    }
+    async fn delete_consent_and_revoke_tokens(
+        &self,
+        _client_id: &str,
+        _user_id: &UserId,
+    ) -> Result<Option<crate::storage::traits::ConsentRevocationCounts>, StoreError> {
+        Err(StoreError::Database(
+            "oauth: postgres not yet implemented".into(),
+        ))
+    }
 }

--- a/crates/core/src/storage/sqlite/oauth.rs
+++ b/crates/core/src/storage/sqlite/oauth.rs
@@ -723,4 +723,77 @@ impl OAuthStore for SqliteStore {
             .await
             .map_err(|e| StoreError::Database(e.to_string()))
     }
+
+    async fn delete_consent_and_revoke_tokens(
+        &self,
+        client_id: &str,
+        user_id: &UserId,
+    ) -> Result<Option<crate::storage::traits::ConsentRevocationCounts>, StoreError> {
+        let client_id = client_id.to_string();
+        let user_id_str = user_id.0.hyphenated().to_string();
+        let revoked_at = chrono::Utc::now().to_rfc3339();
+        self.conn()
+            .call(move |conn| {
+                let tx = conn
+                    .transaction()
+                    .map_err(tokio_rusqlite::Error::Rusqlite)?;
+                let consent_deleted = tx
+                    .execute(
+                        "DELETE FROM oauth_consents WHERE client_id = ?1 AND user_id = ?2",
+                        rusqlite::params![client_id, user_id_str],
+                    )
+                    .map_err(tokio_rusqlite::Error::Rusqlite)?;
+                if consent_deleted == 0 {
+                    tx.commit().map_err(tokio_rusqlite::Error::Rusqlite)?;
+                    return Ok(None);
+                }
+                let access_revoked = tx
+                    .execute(
+                        "UPDATE oauth_access_tokens SET revoked_at = ?3 \
+                         WHERE client_id = ?1 AND user_id = ?2 AND revoked_at IS NULL",
+                        rusqlite::params![client_id, user_id_str, revoked_at],
+                    )
+                    .map_err(tokio_rusqlite::Error::Rusqlite)?;
+                let refresh_revoked = tx
+                    .execute(
+                        "UPDATE oauth_refresh_tokens SET revoked_at = ?3 \
+                         WHERE client_id = ?1 AND user_id = ?2 AND revoked_at IS NULL",
+                        rusqlite::params![client_id, user_id_str, revoked_at],
+                    )
+                    .map_err(tokio_rusqlite::Error::Rusqlite)?;
+                tx.commit().map_err(tokio_rusqlite::Error::Rusqlite)?;
+                Ok(Some(crate::storage::traits::ConsentRevocationCounts {
+                    access_tokens: access_revoked as u32,
+                    refresh_tokens: refresh_revoked as u32,
+                }))
+            })
+            .await
+            .map_err(|e| StoreError::Database(e.to_string()))
+    }
+
+    async fn list_oauth_consents_for_client(
+        &self,
+        client_id: &str,
+    ) -> Result<Vec<OAuthConsent>, StoreError> {
+        let client_id = client_id.to_string();
+        self.conn()
+            .call(move |conn| {
+                let mut stmt = conn
+                    .prepare(
+                        "SELECT client_id, user_id, scopes, granted_at \
+                         FROM oauth_consents WHERE client_id = ?1",
+                    )
+                    .map_err(tokio_rusqlite::Error::Rusqlite)?;
+                let rows = stmt
+                    .query_map(rusqlite::params![client_id], row_to_consent)
+                    .map_err(tokio_rusqlite::Error::Rusqlite)?;
+                let mut out = Vec::new();
+                for r in rows {
+                    out.push(r.map_err(tokio_rusqlite::Error::Rusqlite)?);
+                }
+                Ok(out)
+            })
+            .await
+            .map_err(|e| StoreError::Database(e.to_string()))
+    }
 }

--- a/crates/core/src/storage/traits/mod.rs
+++ b/crates/core/src/storage/traits/mod.rs
@@ -21,7 +21,7 @@ pub use mcp_oauth_store::McpOAuthStore;
 pub use mcp_server_workspace_store::McpServerWorkspaceStore;
 pub use mcp_store::McpStore;
 pub use oauth_provider_client_store::OAuthProviderClientStore;
-pub use oauth_store::OAuthStore;
+pub use oauth_store::{ConsentRevocationCounts, OAuthStore};
 pub use oidc_store::OidcStore;
 pub use policy_store::PolicyStore;
 pub use secret_history_store::SecretHistoryStore;

--- a/crates/core/src/storage/traits/oauth_store.rs
+++ b/crates/core/src/storage/traits/oauth_store.rs
@@ -63,4 +63,32 @@ pub trait OAuthStore: Send + Sync {
         user_id: &UserId,
     ) -> Result<Option<OAuthConsent>, StoreError>;
     async fn upsert_oauth_consent(&self, consent: &OAuthConsent) -> Result<(), StoreError>;
+
+    /// List every consent granted to the given OAuth client. Issue #10.
+    ///
+    /// Returned in any order; callers that need a stable order should sort
+    /// at the boundary (UI / API).
+    async fn list_oauth_consents_for_client(
+        &self,
+        client_id: &str,
+    ) -> Result<Vec<OAuthConsent>, StoreError>;
+
+    /// Delete the consent row and revoke every access and refresh token issued
+    /// to the given `(client_id, user_id)` pair, atomically. Issue #10.
+    ///
+    /// Returns `None` if no consent existed (handlers map this to HTTP 404);
+    /// otherwise `Some(counts)` with the number of access and refresh tokens
+    /// revoked, which the audit event payload records.
+    async fn delete_consent_and_revoke_tokens(
+        &self,
+        client_id: &str,
+        user_id: &UserId,
+    ) -> Result<Option<ConsentRevocationCounts>, StoreError>;
+}
+
+/// Counts of tokens revoked by [`OAuthStore::delete_consent_and_revoke_tokens`].
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct ConsentRevocationCounts {
+    pub access_tokens: u32,
+    pub refresh_tokens: u32,
 }

--- a/crates/server/src/routes/admin_api/policies/crud.rs
+++ b/crates/server/src/routes/admin_api/policies/crud.rs
@@ -164,6 +164,10 @@ pub(super) async fn get_schema_reference(
             "Add or remove tags on agents, devices, or system",
         ),
         (actions::UNPROTECT, "Reveal a credential's raw secret value"),
+        (
+            actions::MANAGE_CONSENTS,
+            "View or revoke OAuth consent grants on a workspace",
+        ),
     ]
     .into_iter()
     .collect();

--- a/crates/server/src/routes/admin_api/workspaces/consents.rs
+++ b/crates/server/src/routes/admin_api/workspaces/consents.rs
@@ -1,0 +1,166 @@
+//! Issue #10 — view and delete OAuth consent grants for a workspace.
+//!
+//! Mounted under `/api/v1/workspaces/{id}/consents`.
+
+use axum::{
+    extract::{Path, State},
+    http::StatusCode,
+    Json,
+};
+use chrono::{DateTime, Utc};
+use serde::Serialize;
+use uuid::Uuid;
+
+use agent_cordon_core::domain::audit::{AuditDecision, AuditEvent, AuditEventType};
+use agent_cordon_core::domain::user::UserId;
+use agent_cordon_core::domain::workspace::WorkspaceId;
+use agent_cordon_core::policy::{actions, claim_keys, PolicyPrincipal, PolicyResource};
+
+use crate::authz::PolicyCaller;
+use crate::extractors::AuthenticatedUser;
+use crate::response::{ApiError, ApiResponse};
+use crate::state::AppState;
+
+use super::check_manage_workspaces;
+
+/// One row in the consent-list response.
+#[derive(Debug, Serialize)]
+pub struct ConsentGrantResponse {
+    pub user_id: Uuid,
+    pub username: String,
+    pub scopes: Vec<String>,
+    pub granted_at: DateTime<Utc>,
+}
+
+/// `GET /api/v1/workspaces/{id}/consents` — list all OAuth consents granted to
+/// the workspace's OAuth client.
+pub(super) async fn list_consents(
+    State(state): State<AppState>,
+    auth: AuthenticatedUser,
+    Path(id): Path<Uuid>,
+) -> Result<Json<ApiResponse<Vec<ConsentGrantResponse>>>, ApiError> {
+    check_manage_workspaces(&state, &auth).await?;
+
+    let workspace = state
+        .store
+        .get_workspace(&WorkspaceId(id))
+        .await?
+        .ok_or_else(|| ApiError::NotFound("workspace not found".to_string()))?;
+
+    // No OAuth client yet → no possible consents.
+    let pk_hash = match workspace.pk_hash.as_deref() {
+        Some(s) => s,
+        None => return Ok(Json(ApiResponse::ok(Vec::new()))),
+    };
+    let client = match state
+        .store
+        .get_oauth_client_by_public_key_hash(pk_hash)
+        .await?
+    {
+        Some(c) => c,
+        None => return Ok(Json(ApiResponse::ok(Vec::new()))),
+    };
+
+    let consents = state
+        .store
+        .list_oauth_consents_for_client(&client.client_id)
+        .await?;
+
+    let mut rows = Vec::with_capacity(consents.len());
+    for c in consents {
+        let username = resolve_username(&state, &c.user_id).await;
+        rows.push(ConsentGrantResponse {
+            user_id: c.user_id.0,
+            username,
+            scopes: c.scopes.iter().map(|s| s.to_string()).collect(),
+            granted_at: c.granted_at,
+        });
+    }
+    Ok(Json(ApiResponse::ok(rows)))
+}
+
+/// Best-effort username lookup. Falls back to the UUID string if the user has
+/// been deleted but their consent row hasn't been cleaned up.
+async fn resolve_username(state: &AppState, user_id: &UserId) -> String {
+    match state.store.get_user(user_id).await {
+        Ok(Some(u)) => u.display_name.unwrap_or(u.username),
+        _ => user_id.0.to_string(),
+    }
+}
+
+/// `DELETE /api/v1/workspaces/{id}/consents/{user_id}` — revoke a consent grant.
+///
+/// Cascades: deletes the consent row and revokes every access and refresh
+/// token issued to the `(client_id, user_id)` pair, atomically.
+pub(super) async fn delete_consent(
+    State(state): State<AppState>,
+    auth: AuthenticatedUser,
+    Path((workspace_id, target_user_id)): Path<(Uuid, Uuid)>,
+) -> Result<StatusCode, ApiError> {
+    // Cedar gate is below — after we know the workspace + target consent_user_id.
+    let workspace = state
+        .store
+        .get_workspace(&WorkspaceId(workspace_id))
+        .await?
+        .ok_or_else(|| ApiError::NotFound("workspace not found".to_string()))?;
+    let pk_hash = workspace
+        .pk_hash
+        .as_deref()
+        .ok_or_else(|| ApiError::NotFound("no consent for that user".to_string()))?;
+    let client = state
+        .store
+        .get_oauth_client_by_public_key_hash(pk_hash)
+        .await?
+        .ok_or_else(|| ApiError::NotFound("no consent for that user".to_string()))?;
+
+    let target = UserId(target_user_id);
+
+    // Cedar self-permit: admins can manage any consent; non-admins only their own.
+    let corr = uuid::Uuid::new_v4().to_string();
+    let decision = state
+        .authz
+        .request(
+            PolicyCaller::Principal {
+                principal: PolicyPrincipal::User(&auth.user),
+                oauth_claims: None,
+            },
+            &corr,
+        )
+        .claim(
+            claim_keys::CONSENT_USER_ID,
+            target.0.hyphenated().to_string(),
+        )
+        .check_with_reasons(actions::MANAGE_CONSENTS, &PolicyResource::System)
+        .await
+        .map_err(|e| ApiError::Internal(format!("policy: {e:?}")))?;
+    if !matches!(
+        decision.decision,
+        agent_cordon_core::domain::policy::PolicyDecisionResult::Permit
+    ) {
+        return Err(ApiError::Forbidden("access denied by policy".to_string()));
+    }
+
+    let counts = state
+        .store
+        .delete_consent_and_revoke_tokens(&client.client_id, &target)
+        .await?
+        .ok_or_else(|| ApiError::NotFound("no consent for that user".to_string()))?;
+
+    let event = AuditEvent::builder(AuditEventType::ConsentRevoked)
+        .action("delete")
+        .user_actor(&auth.user)
+        .resource("oauth_consent", &target.0.to_string())
+        .decision(AuditDecision::Permit, None)
+        .details(serde_json::json!({
+            "workspace_id": workspace.id.0.to_string(),
+            "client_id": client.client_id,
+            "access_tokens_revoked": counts.access_tokens,
+            "refresh_tokens_revoked": counts.refresh_tokens,
+        }))
+        .build();
+    if let Err(e) = state.store.append_audit_event(&event).await {
+        tracing::warn!(error = %e, "failed to write ConsentRevoked audit event");
+    }
+
+    Ok(StatusCode::NO_CONTENT)
+}

--- a/crates/server/src/routes/admin_api/workspaces/mod.rs
+++ b/crates/server/src/routes/admin_api/workspaces/mod.rs
@@ -1,3 +1,4 @@
+mod consents;
 mod crud;
 mod operations;
 
@@ -74,6 +75,11 @@ pub fn routes() -> Router<AppState> {
         .route(
             "/workspaces/{id}/tags/{tag}",
             axum::routing::delete(remove_workspace_tag),
+        )
+        .route("/workspaces/{id}/consents", get(consents::list_consents))
+        .route(
+            "/workspaces/{id}/consents/{user_id}",
+            axum::routing::delete(consents::delete_consent),
         )
 }
 

--- a/crates/server/templates/pages/workspaces/detail.html
+++ b/crates/server/templates/pages/workspaces/detail.html
@@ -29,6 +29,10 @@
                             :class="{ 'tab-active': activeTab === 'mcp' }"
                             :aria-selected="activeTab === 'mcp'"
                             @click="activeTab = 'mcp'; loadMcpServers()">MCP Servers</button>
+                    <button class="tab-btn" role="tab"
+                            :class="{ 'tab-active': activeTab === 'consents' }"
+                            :aria-selected="activeTab === 'consents'"
+                            @click="activeTab = 'consents'; loadConsents()">Consents</button>
                 </nav>
 
                 <!-- Details tab -->
@@ -103,6 +107,43 @@
                     </div>
                 </div>
 
+                <!-- Consents tab (issue #10) -->
+                <div class="tab-content" role="tabpanel" x-show="activeTab === 'consents'">
+                    <div x-show="consentsLoading" class="page-loader page-loader-sm">
+                        <div class="page-loader-dots"><span class="page-loader-dot"></span><span class="page-loader-dot"></span><span class="page-loader-dot"></span></div>
+                    </div>
+                    <div x-show="!consentsLoading && consents.length === 0" class="empty-state empty-state-compact">
+                        <p>No consent grants for this workspace.</p>
+                    </div>
+                    <table x-show="!consentsLoading && consents.length > 0" class="tbl tbl-flush">
+                        <thead>
+                            <tr>
+                                <th>User</th>
+                                <th>Scopes</th>
+                                <th>Granted</th>
+                                <th></th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <template x-for="c in consents" :key="c.user_id">
+                                <tr>
+                                    <td x-text="c.username"></td>
+                                    <td>
+                                        <template x-for="s in (c.scopes || [])" :key="s">
+                                            <span class="tag" x-text="s"></span>
+                                        </template>
+                                    </td>
+                                    <td class="timestamp" x-text="formatDateTime(c.granted_at)"></td>
+                                    <td>
+                                        <button class="btn btn-danger btn-sm"
+                                                @click="revokeConsent(c)">Revoke</button>
+                                    </td>
+                                </tr>
+                            </template>
+                        </tbody>
+                    </table>
+                </div>
+
                 <!-- MCP Servers tab -->
                 <div class="tab-content" role="tabpanel" x-show="activeTab === 'mcp'">
                     <div x-show="mcpLoading" class="page-loader page-loader-sm">
@@ -170,6 +211,9 @@ function workspaceDetailPage() {
         mcpServers: [],
         mcpLoading: false,
         mcpLoaded: false,
+        consents: [],
+        consentsLoading: false,
+        consentsLoaded: false,
         deleteModal: false,
         deleteTargetName: '',
 
@@ -251,6 +295,41 @@ function workspaceDetailPage() {
             } catch(e) { showToast('Failed to load MCP servers', 'error'); }
             this.mcpLoading = false;
             this.mcpLoaded = true;
+        },
+
+        async loadConsents() {
+            if (this.consentsLoaded) return;
+            this.consentsLoading = true;
+            try {
+                var resp = await fetch('/api/v1/workspaces/{{ workspace_id }}/consents');
+                if (resp.ok) {
+                    var data = await resp.json();
+                    this.consents = (data.data || []).slice().sort(function(a, b) {
+                        return (b.granted_at || '').localeCompare(a.granted_at || '');
+                    });
+                }
+            } catch(e) { showToast('Failed to load consents', 'error'); }
+            this.consentsLoading = false;
+            this.consentsLoaded = true;
+        },
+
+        async revokeConsent(c) {
+            if (!confirm('Revoke ' + (c.username || c.user_id) + "'s consent? This deletes the grant and revokes all of their tokens for this workspace.")) {
+                return;
+            }
+            try {
+                var resp = await fetch('/api/v1/workspaces/{{ workspace_id }}/consents/' + encodeURIComponent(c.user_id), {
+                    method: 'DELETE',
+                    headers: { 'X-CSRF-Token': getCsrfToken() }
+                });
+                if (resp.ok) {
+                    this.consents = this.consents.filter(function(x) { return x.user_id !== c.user_id; });
+                    showToast('Consent revoked', 'success');
+                } else {
+                    var err = await resp.json().catch(function() { return {}; });
+                    showToast((err.error && err.error.message) || 'Failed to revoke consent', 'error');
+                }
+            } catch(e) { showToast('Failed to revoke consent', 'error'); }
         },
 
         openDelete() {

--- a/crates/server/templates/partials/workspace_detail_pane.html
+++ b/crates/server/templates/partials/workspace_detail_pane.html
@@ -41,6 +41,10 @@
                             :class="{ 'tab-active': activeTab === 'mcp' }"
                             :aria-selected="activeTab === 'mcp'"
                             @click="activeTab = 'mcp'; loadMcpServers()">MCP Servers</button>
+                    <button class="tab-btn" role="tab"
+                            :class="{ 'tab-active': activeTab === 'consents' }"
+                            :aria-selected="activeTab === 'consents'"
+                            @click="activeTab = 'consents'; loadConsents()">Consents</button>
                 </nav>
 
                 <!-- Details tab -->
@@ -182,6 +186,43 @@
                         </tbody>
                     </table>
                 </div>
+
+                <!-- Consents tab (issue #10) -->
+                <div class="tab-content" role="tabpanel" x-show="activeTab === 'consents'">
+                    <div x-show="consentsLoading" class="page-loader page-loader-sm">
+                        <div class="page-loader-dots"><span class="page-loader-dot"></span><span class="page-loader-dot"></span><span class="page-loader-dot"></span></div>
+                    </div>
+                    <div x-show="!consentsLoading && consents.length === 0" class="empty-state empty-state-compact">
+                        <p>No consent grants for this workspace.</p>
+                    </div>
+                    <table x-show="!consentsLoading && consents.length > 0" class="tbl tbl-flush">
+                        <thead>
+                            <tr>
+                                <th>User</th>
+                                <th>Scopes</th>
+                                <th>Granted</th>
+                                <th></th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <template x-for="c in consents" :key="c.user_id">
+                                <tr>
+                                    <td x-text="c.username"></td>
+                                    <td>
+                                        <template x-for="s in (c.scopes || [])" :key="s">
+                                            <span class="tag" x-text="s"></span>
+                                        </template>
+                                    </td>
+                                    <td class="timestamp" x-text="formatDateTime(c.granted_at)"></td>
+                                    <td>
+                                        <button class="btn btn-danger btn-sm"
+                                                @click="revokeConsent(c)">Revoke</button>
+                                    </td>
+                                </tr>
+                            </template>
+                        </tbody>
+                    </table>
+                </div>
             </div>
         </div>
         </template>
@@ -223,6 +264,9 @@ function workspaceDetailPane() {
         mcpServers: [],
         mcpLoading: false,
         mcpLoaded: false,
+        consents: [],
+        consentsLoading: false,
+        consentsLoaded: false,
         deleteModal: false,
         deleteTargetName: '',
 
@@ -292,6 +336,43 @@ function workspaceDetailPane() {
             } catch(e) { showToast('Failed to load MCP servers', 'error'); }
             this.mcpLoading = false;
             this.mcpLoaded = true;
+        },
+
+        async loadConsents() {
+            if (this.consentsLoaded) return;
+            this.consentsLoading = true;
+            try {
+                var id = '{{ workspace_id }}';
+                var resp = await fetch('/api/v1/workspaces/' + id + '/consents');
+                if (resp.ok) {
+                    var data = await resp.json();
+                    this.consents = (data.data || []).slice().sort(function(a, b) {
+                        return (b.granted_at || '').localeCompare(a.granted_at || '');
+                    });
+                }
+            } catch(e) { showToast('Failed to load consents', 'error'); }
+            this.consentsLoading = false;
+            this.consentsLoaded = true;
+        },
+
+        async revokeConsent(c) {
+            if (!confirm('Revoke ' + (c.username || c.user_id) + "'s consent? This deletes the grant and revokes all of their tokens for this workspace.")) {
+                return;
+            }
+            try {
+                var id = '{{ workspace_id }}';
+                var resp = await fetch('/api/v1/workspaces/' + id + '/consents/' + encodeURIComponent(c.user_id), {
+                    method: 'DELETE',
+                    headers: { 'X-CSRF-Token': getCsrfToken() }
+                });
+                if (resp.ok) {
+                    this.consents = this.consents.filter(function(x) { return x.user_id !== c.user_id; });
+                    showToast('Consent revoked', 'success');
+                } else {
+                    var err = await resp.json().catch(function() { return {}; });
+                    showToast((err.error && err.error.message) || 'Failed to revoke consent', 'error');
+                }
+            } catch(e) { showToast('Failed to revoke consent', 'error'); }
         },
 
         async toggleEnabled() {

--- a/crates/server/tests/consent_grants.rs
+++ b/crates/server/tests/consent_grants.rs
@@ -1,0 +1,590 @@
+//! Issue #10 — view and delete OAuth consent grants per workspace.
+//!
+//! Vertical TDD slices through the admin REST API + Cedar authz + storage cascade.
+
+use axum::body::Body;
+use axum::http::{header, Method, Request, StatusCode};
+use http_body_util::BodyExt;
+use tower::ServiceExt;
+
+use agent_cordon_core::domain::user::{UserId, UserRole};
+use agent_cordon_core::domain::workspace::Workspace;
+use agent_cordon_core::oauth2::types::{
+    OAuthAccessToken, OAuthClient, OAuthConsent, OAuthRefreshToken, OAuthScope,
+};
+use agent_cordon_core::storage::traits::AuditFilter;
+use agent_cordon_core::storage::Store;
+use agent_cordon_server::test_helpers::TestAppBuilder;
+
+use crate::common::*;
+
+/// Seed an OAuth client tied to the workspace's `pk_hash` and return its
+/// `client_id`. One client per workspace, matching production registration.
+async fn seed_oauth_client(
+    store: &dyn Store,
+    workspace: &Workspace,
+    created_by: &UserId,
+) -> String {
+    let pk_hash = workspace
+        .pk_hash
+        .clone()
+        .unwrap_or_else(|| format!("test-pk-hash-{}", workspace.id.0));
+    let client_id = format!("ac_cli_test_{}", workspace.id.0);
+    let client = OAuthClient {
+        id: uuid::Uuid::new_v4(),
+        client_id: client_id.clone(),
+        client_secret_hash: None,
+        workspace_name: workspace.name.clone(),
+        public_key_hash: pk_hash,
+        redirect_uris: vec!["http://localhost:9999/callback".to_string()],
+        allowed_scopes: vec![
+            OAuthScope::CredentialsDiscover,
+            OAuthScope::CredentialsVend,
+            OAuthScope::McpInvoke,
+        ],
+        created_by_user: created_by.clone(),
+        created_at: chrono::Utc::now(),
+        revoked_at: None,
+    };
+    store
+        .create_oauth_client(&client)
+        .await
+        .expect("seed oauth client");
+    client_id
+}
+
+/// Slice 1 — RED: GET on a workspace with no consents returns 200 and an empty list.
+#[tokio::test]
+async fn get_consents_empty_workspace_returns_200_empty_list() {
+    let ctx = TestAppBuilder::new()
+        .with_agent("ws-no-consents", &[])
+        .build()
+        .await;
+    let _admin = create_test_user(&*ctx.store, "admin", TEST_PASSWORD, UserRole::Admin).await;
+    let (cookie, csrf) = login_user(&ctx.app, "admin", TEST_PASSWORD).await;
+    let full_cookie = combined_cookie(&cookie, &csrf);
+
+    let workspace = ctx.agents.get("ws-no-consents").expect("workspace");
+
+    let (status, body) = send_json(
+        &ctx.app,
+        Method::GET,
+        &format!("/api/v1/workspaces/{}/consents", workspace.id.0),
+        None,
+        Some(&full_cookie),
+        None,
+        None,
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK, "body: {body}");
+    let data = body["data"].as_array().expect("data should be an array");
+    assert!(data.is_empty(), "expected empty list, got: {data:?}");
+}
+
+/// Slice 2 — RED: GET returns the consent rows that exist for the workspace's client.
+#[tokio::test]
+async fn get_consents_returns_existing_grants() {
+    let ctx = TestAppBuilder::new()
+        .with_agent("ws-with-consent", &[])
+        .build()
+        .await;
+    let admin = create_test_user(&*ctx.store, "admin", TEST_PASSWORD, UserRole::Admin).await;
+    let granting_user =
+        create_test_user(&*ctx.store, "alice", TEST_PASSWORD, UserRole::Viewer).await;
+    let (cookie, csrf) = login_user(&ctx.app, "admin", TEST_PASSWORD).await;
+    let full_cookie = combined_cookie(&cookie, &csrf);
+
+    let workspace = ctx.agents.get("ws-with-consent").expect("workspace");
+    let client_id = seed_oauth_client(&*ctx.store, workspace, &admin.id).await;
+
+    let consent = OAuthConsent {
+        client_id: client_id.clone(),
+        user_id: granting_user.id.clone(),
+        scopes: vec![OAuthScope::CredentialsDiscover, OAuthScope::McpInvoke],
+        granted_at: chrono::Utc::now(),
+    };
+    ctx.store
+        .upsert_oauth_consent(&consent)
+        .await
+        .expect("seed consent");
+
+    let (status, body) = send_json(
+        &ctx.app,
+        Method::GET,
+        &format!("/api/v1/workspaces/{}/consents", workspace.id.0),
+        None,
+        Some(&full_cookie),
+        None,
+        None,
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK, "body: {body}");
+    let data = body["data"].as_array().expect("data should be an array");
+    assert_eq!(data.len(), 1, "expected one consent grant, got: {data:?}");
+    let row = &data[0];
+    assert_eq!(
+        row["user_id"].as_str(),
+        Some(granting_user.id.0.to_string().as_str())
+    );
+    let scopes = row["scopes"].as_array().expect("scopes array");
+    assert_eq!(scopes.len(), 2);
+}
+
+/// Slice 3 — RED: the consent row carries the granting user's username
+/// (server-enriched so the UI doesn't have to make per-row user lookups).
+#[tokio::test]
+async fn get_consents_enriches_username() {
+    let ctx = TestAppBuilder::new()
+        .with_agent("ws-username", &[])
+        .build()
+        .await;
+    let admin = create_test_user(&*ctx.store, "admin", TEST_PASSWORD, UserRole::Admin).await;
+    let granter = create_test_user(
+        &*ctx.store,
+        "bob-the-granter",
+        TEST_PASSWORD,
+        UserRole::Viewer,
+    )
+    .await;
+    let (cookie, csrf) = login_user(&ctx.app, "admin", TEST_PASSWORD).await;
+    let full_cookie = combined_cookie(&cookie, &csrf);
+
+    let workspace = ctx.agents.get("ws-username").expect("workspace");
+    let client_id = seed_oauth_client(&*ctx.store, workspace, &admin.id).await;
+    ctx.store
+        .upsert_oauth_consent(&OAuthConsent {
+            client_id,
+            user_id: granter.id.clone(),
+            scopes: vec![OAuthScope::McpInvoke],
+            granted_at: chrono::Utc::now(),
+        })
+        .await
+        .expect("seed consent");
+
+    let (status, body) = send_json(
+        &ctx.app,
+        Method::GET,
+        &format!("/api/v1/workspaces/{}/consents", workspace.id.0),
+        None,
+        Some(&full_cookie),
+        None,
+        None,
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK, "body: {body}");
+    let row = &body["data"][0];
+    // create_test_user sets display_name = "Test {username}"; enrichment
+    // prefers display_name over the raw username, same as workspace owner
+    // enrichment elsewhere in admin_api.
+    assert_eq!(row["username"].as_str(), Some("Test bob-the-granter"));
+}
+
+/// Slice 5 — RED: admin DELETE removes the consent row and returns 204.
+#[tokio::test]
+async fn delete_consent_as_admin_removes_row_returns_204() {
+    let ctx = TestAppBuilder::new()
+        .with_agent("ws-delete", &[])
+        .build()
+        .await;
+    let admin = create_test_user(&*ctx.store, "admin", TEST_PASSWORD, UserRole::Admin).await;
+    let granter = create_test_user(&*ctx.store, "carol", TEST_PASSWORD, UserRole::Viewer).await;
+    let (cookie, csrf) = login_user(&ctx.app, "admin", TEST_PASSWORD).await;
+    let full_cookie = combined_cookie(&cookie, &csrf);
+
+    let workspace = ctx.agents.get("ws-delete").expect("workspace");
+    let client_id = seed_oauth_client(&*ctx.store, workspace, &admin.id).await;
+    ctx.store
+        .upsert_oauth_consent(&OAuthConsent {
+            client_id: client_id.clone(),
+            user_id: granter.id.clone(),
+            scopes: vec![OAuthScope::McpInvoke],
+            granted_at: chrono::Utc::now(),
+        })
+        .await
+        .expect("seed consent");
+    let (status, _) = send_json_auto_csrf(
+        &ctx.app,
+        Method::DELETE,
+        &format!(
+            "/api/v1/workspaces/{}/consents/{}",
+            workspace.id.0, granter.id.0
+        ),
+        None,
+        Some(&full_cookie),
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::NO_CONTENT);
+
+    let row = ctx
+        .store
+        .get_oauth_consent(&client_id, &granter.id)
+        .await
+        .expect("query consent");
+    assert!(row.is_none(), "consent row should be deleted");
+}
+
+/// Slice 6 — RED: DELETE atomically revokes access AND refresh tokens for the
+/// (client_id, user_id) pair. Tokens belonging to other users of the same
+/// client are not touched.
+#[tokio::test]
+async fn delete_consent_revokes_access_and_refresh_tokens() {
+    let ctx = TestAppBuilder::new()
+        .with_agent("ws-cascade", &[])
+        .build()
+        .await;
+    let admin = create_test_user(&*ctx.store, "admin", TEST_PASSWORD, UserRole::Admin).await;
+    let granter = create_test_user(&*ctx.store, "dave", TEST_PASSWORD, UserRole::Viewer).await;
+    let bystander = create_test_user(&*ctx.store, "evelyn", TEST_PASSWORD, UserRole::Viewer).await;
+    let (cookie, csrf) = login_user(&ctx.app, "admin", TEST_PASSWORD).await;
+    let full_cookie = combined_cookie(&cookie, &csrf);
+
+    let workspace = ctx.agents.get("ws-cascade").expect("workspace");
+    let client_id = seed_oauth_client(&*ctx.store, workspace, &admin.id).await;
+
+    ctx.store
+        .upsert_oauth_consent(&OAuthConsent {
+            client_id: client_id.clone(),
+            user_id: granter.id.clone(),
+            scopes: vec![OAuthScope::McpInvoke],
+            granted_at: chrono::Utc::now(),
+        })
+        .await
+        .expect("seed consent");
+
+    let now = chrono::Utc::now();
+    let exp = now + chrono::Duration::hours(1);
+    let granter_at = OAuthAccessToken {
+        token_hash: format!("hash-at-{}", granter.id.0),
+        client_id: client_id.clone(),
+        user_id: granter.id.clone(),
+        scopes: vec![OAuthScope::McpInvoke],
+        created_at: now,
+        expires_at: exp,
+        revoked_at: None,
+    };
+    let bystander_at = OAuthAccessToken {
+        token_hash: format!("hash-at-{}", bystander.id.0),
+        client_id: client_id.clone(),
+        user_id: bystander.id.clone(),
+        scopes: vec![OAuthScope::McpInvoke],
+        created_at: now,
+        expires_at: exp,
+        revoked_at: None,
+    };
+    ctx.store
+        .create_oauth_access_token(&granter_at)
+        .await
+        .unwrap();
+    ctx.store
+        .create_oauth_access_token(&bystander_at)
+        .await
+        .unwrap();
+
+    let granter_rt = OAuthRefreshToken {
+        token_hash: format!("hash-rt-{}", granter.id.0),
+        client_id: client_id.clone(),
+        user_id: granter.id.clone(),
+        scopes: vec![OAuthScope::McpInvoke],
+        access_token_hash: granter_at.token_hash.clone(),
+        created_at: now,
+        expires_at: exp,
+        revoked_at: None,
+    };
+    ctx.store
+        .create_oauth_refresh_token(&granter_rt)
+        .await
+        .unwrap();
+
+    let (status, _) = send_json_auto_csrf(
+        &ctx.app,
+        Method::DELETE,
+        &format!(
+            "/api/v1/workspaces/{}/consents/{}",
+            workspace.id.0, granter.id.0
+        ),
+        None,
+        Some(&full_cookie),
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::NO_CONTENT);
+
+    // Granter tokens revoked.
+    let at = ctx
+        .store
+        .get_oauth_access_token(&granter_at.token_hash)
+        .await
+        .unwrap()
+        .expect("access token row");
+    assert!(
+        at.revoked_at.is_some(),
+        "granter access token must be revoked"
+    );
+
+    let rt = ctx
+        .store
+        .get_oauth_refresh_token(&granter_rt.token_hash)
+        .await
+        .unwrap()
+        .expect("refresh token row");
+    assert!(
+        rt.revoked_at.is_some(),
+        "granter refresh token must be revoked"
+    );
+
+    // Bystander token untouched.
+    let other = ctx
+        .store
+        .get_oauth_access_token(&bystander_at.token_hash)
+        .await
+        .unwrap()
+        .expect("bystander access token row");
+    assert!(
+        other.revoked_at.is_none(),
+        "bystander access token must NOT be revoked"
+    );
+}
+
+/// Slice 7 — RED: DELETE emits a `ConsentRevoked` audit event carrying actor,
+/// resource, and the token-revocation counts.
+#[tokio::test]
+async fn delete_consent_emits_consent_revoked_audit_event() {
+    let ctx = TestAppBuilder::new()
+        .with_agent("ws-audit", &[])
+        .build()
+        .await;
+    let admin = create_test_user(&*ctx.store, "admin", TEST_PASSWORD, UserRole::Admin).await;
+    let granter = create_test_user(&*ctx.store, "frank", TEST_PASSWORD, UserRole::Viewer).await;
+    let (cookie, csrf) = login_user(&ctx.app, "admin", TEST_PASSWORD).await;
+    let full_cookie = combined_cookie(&cookie, &csrf);
+
+    let workspace = ctx.agents.get("ws-audit").expect("workspace");
+    let client_id = seed_oauth_client(&*ctx.store, workspace, &admin.id).await;
+    ctx.store
+        .upsert_oauth_consent(&OAuthConsent {
+            client_id: client_id.clone(),
+            user_id: granter.id.clone(),
+            scopes: vec![OAuthScope::McpInvoke],
+            granted_at: chrono::Utc::now(),
+        })
+        .await
+        .expect("seed consent");
+
+    let _ = send_json_auto_csrf(
+        &ctx.app,
+        Method::DELETE,
+        &format!(
+            "/api/v1/workspaces/{}/consents/{}",
+            workspace.id.0, granter.id.0
+        ),
+        None,
+        Some(&full_cookie),
+        None,
+    )
+    .await;
+
+    let events = ctx
+        .store
+        .list_audit_events_filtered(&AuditFilter {
+            limit: 100,
+            event_type: Some("consent_revoked".to_string()),
+            ..Default::default()
+        })
+        .await
+        .expect("list audit events");
+    assert_eq!(events.len(), 1, "expected one ConsentRevoked event");
+    let ev = &events[0];
+    assert_eq!(ev.resource_type, "oauth_consent");
+    assert!(
+        ev.resource_id.as_deref() == Some(granter.id.0.to_string().as_str()),
+        "audit resource_id should be the revoked user_id, got {:?}",
+        ev.resource_id
+    );
+}
+
+/// Slice 9 — RED: a non-admin (viewer-role) user can DELETE *their own*
+/// consent grant via the Cedar `manage_consents` self-permit rule.
+#[tokio::test]
+async fn delete_own_consent_as_viewer_succeeds() {
+    let ctx = TestAppBuilder::new()
+        .with_agent("ws-self", &[])
+        .build()
+        .await;
+    let admin = create_test_user(&*ctx.store, "admin", TEST_PASSWORD, UserRole::Admin).await;
+    let viewer = create_test_user(&*ctx.store, "gina", TEST_PASSWORD, UserRole::Viewer).await;
+    let (cookie, csrf) = login_user(&ctx.app, "gina", TEST_PASSWORD).await;
+    let full_cookie = combined_cookie(&cookie, &csrf);
+
+    let workspace = ctx.agents.get("ws-self").expect("workspace");
+    let client_id = seed_oauth_client(&*ctx.store, workspace, &admin.id).await;
+    ctx.store
+        .upsert_oauth_consent(&OAuthConsent {
+            client_id: client_id.clone(),
+            user_id: viewer.id.clone(),
+            scopes: vec![OAuthScope::McpInvoke],
+            granted_at: chrono::Utc::now(),
+        })
+        .await
+        .expect("seed consent");
+
+    let (status, _) = send_json_auto_csrf(
+        &ctx.app,
+        Method::DELETE,
+        &format!(
+            "/api/v1/workspaces/{}/consents/{}",
+            workspace.id.0, viewer.id.0
+        ),
+        None,
+        Some(&full_cookie),
+        None,
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::NO_CONTENT,
+        "viewer should be able to delete own consent"
+    );
+
+    let row = ctx
+        .store
+        .get_oauth_consent(&client_id, &viewer.id)
+        .await
+        .expect("query consent");
+    assert!(row.is_none(), "consent row should be deleted");
+}
+
+/// Slice 10 — RED: a non-admin viewer is forbidden from deleting *someone
+/// else's* consent grant. Distinguishes self-permit from blanket permit.
+#[tokio::test]
+async fn delete_other_users_consent_as_viewer_is_forbidden() {
+    let ctx = TestAppBuilder::new()
+        .with_agent("ws-other", &[])
+        .build()
+        .await;
+    let admin = create_test_user(&*ctx.store, "admin", TEST_PASSWORD, UserRole::Admin).await;
+    let _viewer = create_test_user(&*ctx.store, "harry", TEST_PASSWORD, UserRole::Viewer).await;
+    let granter = create_test_user(&*ctx.store, "iris", TEST_PASSWORD, UserRole::Viewer).await;
+    let (cookie, csrf) = login_user(&ctx.app, "harry", TEST_PASSWORD).await;
+    let full_cookie = combined_cookie(&cookie, &csrf);
+
+    let workspace = ctx.agents.get("ws-other").expect("workspace");
+    let client_id = seed_oauth_client(&*ctx.store, workspace, &admin.id).await;
+    ctx.store
+        .upsert_oauth_consent(&OAuthConsent {
+            client_id: client_id.clone(),
+            user_id: granter.id.clone(),
+            scopes: vec![OAuthScope::McpInvoke],
+            granted_at: chrono::Utc::now(),
+        })
+        .await
+        .expect("seed consent");
+
+    let (status, _) = send_json_auto_csrf(
+        &ctx.app,
+        Method::DELETE,
+        &format!(
+            "/api/v1/workspaces/{}/consents/{}",
+            workspace.id.0, granter.id.0
+        ),
+        None,
+        Some(&full_cookie),
+        None,
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::FORBIDDEN,
+        "viewer must not delete others' consent"
+    );
+
+    let row = ctx
+        .store
+        .get_oauth_consent(&client_id, &granter.id)
+        .await
+        .expect("query consent");
+    assert!(row.is_some(), "consent row must still exist");
+}
+
+/// Slice 11 — UI: the workspace detail page renders a "Consents" tab that
+/// wires up to `/api/v1/workspaces/{id}/consents`.
+#[tokio::test]
+async fn workspace_detail_page_renders_consents_tab() {
+    let ctx = TestAppBuilder::new().with_agent("ws-ui", &[]).build().await;
+    let _admin = create_test_user(&*ctx.store, "admin", TEST_PASSWORD, UserRole::Admin).await;
+    let (cookie, csrf) = login_user(&ctx.app, "admin", TEST_PASSWORD).await;
+    let full_cookie = combined_cookie(&cookie, &csrf);
+
+    let workspace = ctx.agents.get("ws-ui").expect("workspace");
+
+    let resp = ctx
+        .app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method(Method::GET)
+                .uri(format!("/workspaces/{}/detail-partial", workspace.id.0))
+                .header(header::COOKIE, &full_cookie)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = String::from_utf8(
+        resp.into_body()
+            .collect()
+            .await
+            .unwrap()
+            .to_bytes()
+            .to_vec(),
+    )
+    .unwrap();
+
+    assert!(
+        body.contains(">Consents</button>"),
+        "expected a Consents tab button in detail.html, body length {}",
+        body.len()
+    );
+    assert!(
+        body.contains("loadConsents()"),
+        "expected loadConsents() wiring in detail.html",
+    );
+    assert!(
+        body.contains("/consents'") || body.contains("/consents/'"),
+        "expected the consents API path baked into the JS calls",
+    );
+}
+
+/// Slice 8 — RED: DELETE on a `(workspace, user_id)` with no consent returns 404.
+#[tokio::test]
+async fn delete_nonexistent_consent_returns_404() {
+    let ctx = TestAppBuilder::new()
+        .with_agent("ws-404", &[])
+        .build()
+        .await;
+    let admin = create_test_user(&*ctx.store, "admin", TEST_PASSWORD, UserRole::Admin).await;
+    let (cookie, csrf) = login_user(&ctx.app, "admin", TEST_PASSWORD).await;
+    let full_cookie = combined_cookie(&cookie, &csrf);
+
+    let workspace = ctx.agents.get("ws-404").expect("workspace");
+    let _client_id = seed_oauth_client(&*ctx.store, workspace, &admin.id).await;
+
+    let phantom_user_id = uuid::Uuid::new_v4();
+    let (status, _) = send_json_auto_csrf(
+        &ctx.app,
+        Method::DELETE,
+        &format!(
+            "/api/v1/workspaces/{}/consents/{}",
+            workspace.id.0, phantom_user_id
+        ),
+        None,
+        Some(&full_cookie),
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+}

--- a/crates/server/tests/main.rs
+++ b/crates/server/tests/main.rs
@@ -11,6 +11,7 @@
 mod common;
 
 mod cedar_policy_routes;
+mod consent_grants;
 mod credential_bugs;
 mod csrf;
 mod device_flow_activate_ui;

--- a/policies/default.cedar
+++ b/policies/default.cedar
@@ -252,3 +252,27 @@ forbid(
 ) when {
   !resource.enabled
 };
+
+// ---------------------------------------------------------------------------
+// SECTION 5: CONSENT GRANTS (issue #10)
+// ---------------------------------------------------------------------------
+
+// 5a. Admins can manage any OAuth consent grant (view/delete).
+permit(
+  principal is AgentCordon::User,
+  action == AgentCordon::Action::"manage_consents",
+  resource
+) when {
+  principal.enabled && principal.role == "admin"
+};
+
+// 5b. Self-serve: any user can manage their *own* consent grant. The
+// handler sets `context.consent_user_id` to the consent's owning user.id;
+// Cedar permits when that matches the calling principal.
+permit(
+  principal is AgentCordon::User,
+  action == AgentCordon::Action::"manage_consents",
+  resource
+) when {
+  principal.enabled && principal.id == context.consent_user_id
+};

--- a/policies/schema.cedarschema.json
+++ b/policies/schema.cedarschema.json
@@ -34,6 +34,9 @@
         "shape": {
           "type": "Record",
           "attributes": {
+            "id": {
+              "type": "String"
+            },
             "name": {
               "type": "String"
             },
@@ -294,6 +297,23 @@
           "context": {
             "type": "Record",
             "attributes": {
+              "timestamp": {
+                "type": "String"
+              }
+            }
+          }
+        }
+      },
+      "manage_consents": {
+        "appliesTo": {
+          "principalTypes": ["User"],
+          "resourceTypes": ["System"],
+          "context": {
+            "type": "Record",
+            "attributes": {
+              "consent_user_id": {
+                "type": "String"
+              },
               "timestamp": {
                 "type": "String"
               }


### PR DESCRIPTION
Closes #10.

Admin UI panel + REST API + Cedar self-permit + atomic cascade revoke.

## Surface

- `GET /api/v1/workspaces/{id}/consents` → `[{user_id, username, scopes, granted_at}]`
- `DELETE /api/v1/workspaces/{id}/consents/{user_id}` → `204` or `404`
- New "Consents" tab on the workspace detail page (both `detail.html` standalone and the split-view partial).

## Authz model (Cedar)

New action `manage_consents` with two permit rules in `default.cedar`:
- `principal.role == "admin"` — admins manage any consent.
- `principal.id == context.consent_user_id` — self-permit for the granting user.

New claim_key `consent_user_id`; new User entity attribute `id` (UUID string) so policies can compare principal.id against context claims. GET path keeps `check_manage_workspaces` (read access mirrors who can see the workspace at all).

## Storage cascade

`OAuthStore::delete_consent_and_revoke_tokens(client_id, user_id)` does it in one SQLite transaction:
1. DELETE the consent row
2. UPDATE `revoked_at` on access tokens matching `(client_id, user_id)`
3. UPDATE `revoked_at` on refresh tokens matching `(client_id, user_id)`

Returns `Option<ConsentRevocationCounts>`; `None` → 404. Counts go into the audit event.

## Audit

- New `AuditEventType::ConsentRevoked` emitted on every successful DELETE with workspace_id, client_id, and revocation counts in details.
- Grant-side audit (`ConsentGranted`) tracked separately in #28.

## TDD log

11 vertical slices, one failing test → minimal impl each. 10 new integration tests in `consent_grants.rs`:

1. GET empty workspace → 200 []
2. GET returns existing grants
3. GET enriches username (display_name preferred)
4. (folded into slice 5)
5. Admin DELETE → 204, consent gone
6. DELETE cascades access + refresh tokens atomically; bystander tokens isolated
7. DELETE emits `ConsentRevoked` audit event with counts
8. DELETE on nonexistent → 404
9. Viewer can DELETE own consent (Cedar self-permit)
10. Viewer cannot DELETE someone else's consent (403)
11. Workspace detail page renders Consents tab + JS wiring

Full suite: 1194 integration tests pass, 31 CLI tests pass. `cargo build --workspace` clean. Honest TDD note: slices 6, 8, 9, and 10 had impl that arose during earlier red-green cycles; their tests serve as behavior pins rather than driving brand-new code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)