### PR TITLE
feat(audit): emit ConsentGranted audit event on consent upsert (#28)

### DIFF
--- a/crates/core/src/domain/audit.rs
+++ b/crates/core/src/domain/audit.rs
@@ -102,7 +102,12 @@ pub enum AuditEventType {
     DeviceCodeDenied,
     DeviceCodeExpired,
 
-    // OAuth2 consent management (issue #10)
+    // OAuth2 consent management (issue #10 / #28)
+    /// User approved an OAuth consent grant for a workspace's client.
+    /// Pairs with `ConsentRevoked`; a re-grant emits a fresh event rather
+    /// than an Updated variant — consent is semantically a new approval,
+    /// not a patch.
+    ConsentGranted,
     /// Admin or self revoked an OAuth consent grant; cascades to token revocation.
     ConsentRevoked,
 

--- a/crates/server/src/routes/oauth/consent.rs
+++ b/crates/server/src/routes/oauth/consent.rs
@@ -238,15 +238,18 @@ pub(crate) async fn authorize_post(
     };
     state.store.upsert_oauth_consent(&consent).await?;
 
-    // Audit: consent granted
-    let event = AuditEvent::builder(AuditEventType::Oauth2TokenAcquired)
-        .action("oauth_consent_granted")
+    // Audit: consent granted (issue #28). Resource shape matches
+    // ConsentRevoked's so admins can correlate grant/revoke pairs by
+    // (resource_type, resource_id).
+    let event = AuditEvent::builder(AuditEventType::ConsentGranted)
+        .action("grant")
         .user_actor(&auth.user)
-        .resource("oauth_client", &client_uuid.to_string())
+        .resource("oauth_consent", &auth.user.id.0.to_string())
         .correlation_id(&corr.0)
         .decision(AuditDecision::Permit, Some("user approved consent"))
         .details(serde_json::json!({
             "client_id": client_id,
+            "client_uuid": client_uuid.to_string(),
             "scopes": OAuthScope::to_scope_string(&scopes),
             "is_new_workspace": is_new,
         }))

--- a/crates/server/tests/v300_oauth_as.rs
+++ b/crates/server/tests/v300_oauth_as.rs
@@ -17,6 +17,7 @@ use tower::ServiceExt;
 
 use agent_cordon_core::domain::user::UserRole;
 use agent_cordon_core::oauth2::types::{OAuthAccessToken, OAuthScope};
+use agent_cordon_core::storage::traits::AuditFilter;
 use agent_cordon_core::storage::Store;
 
 use agent_cordon_server::test_helpers::TestAppBuilder;
@@ -2070,4 +2071,57 @@ async fn test_consent_existing_client_still_works() {
     let (status, body) = send_form(&app, "/api/v1/oauth/token", &token_form).await;
     assert_eq!(status, StatusCode::OK, "token exchange: {}", body);
     assert!(body["access_token"].is_string());
+}
+
+// ===========================================================================
+// Issue #28 — Emit ConsentGranted audit event when a consent is recorded
+// ===========================================================================
+
+/// Issue #28 — RED: POSTing consent emits a dedicated `ConsentGranted` audit
+/// event so the lifecycle pairs symmetrically with `ConsentRevoked` (#10).
+#[tokio::test]
+async fn consent_post_emits_consent_granted_audit_event() {
+    let (app, store, state) = setup().await;
+
+    // Register a client and POST consent. Existing helpers do the full setup;
+    // we only need to assert on the audit log afterwards.
+    let scopes = "credentials:discover";
+    let (_client_id, _client_secret, _at, _rt, _cookie) =
+        full_oauth_flow(&app, &*store, &state, scopes).await;
+
+    let events = store
+        .list_audit_events_filtered(&AuditFilter {
+            limit: 50,
+            event_type: Some("consent_granted".to_string()),
+            ..Default::default()
+        })
+        .await
+        .expect("list audit events");
+
+    assert_eq!(
+        events.len(),
+        1,
+        "expected exactly one ConsentGranted event, got {}",
+        events.len()
+    );
+    let ev = &events[0];
+    assert_eq!(
+        ev.resource_type, "oauth_consent",
+        "resource_type should match ConsentRevoked's shape"
+    );
+    // resource_id should be the granting user's id (the admin in this flow).
+    assert!(
+        ev.resource_id.is_some(),
+        "resource_id (user_id) should be set"
+    );
+    // scopes payload should reflect what was requested.
+    let payload_scopes = ev
+        .metadata
+        .get("scopes")
+        .and_then(|v| v.as_str())
+        .unwrap_or_default();
+    assert!(
+        payload_scopes.contains("credentials:discover"),
+        "details.scopes should contain the requested scope, got {payload_scopes:?}"
+    );
 }


### PR DESCRIPTION
Closes #28.

Adds `AuditEventType::ConsentGranted` and switches the existing emission in `routes/oauth/consent.rs` (which was misclassified as `Oauth2TokenAcquired` with action=`oauth_consent_granted`) to the new dedicated variant.

Shape now mirrors `ConsentRevoked` (from #10):

| field | value |
|---|---|
| `event_type` | `ConsentGranted` |
| `action` | `grant` |
| `resource_type` | `oauth_consent` |
| `resource_id` | granting user_id |
| `details` | `{ client_id, client_uuid, scopes, is_new_workspace }` |

Admins can now correlate grant↔revoke pairs by filtering on `(resource_type="oauth_consent", resource_id=user_id)` with paired event_types. The previous shape nested grants under `Oauth2TokenAcquired`/`oauth_client` which made that correlation awkward.

Re-grant semantics: per the issue body, an upsert that changes scopes emits a fresh `ConsentGranted` rather than an `Updated` variant — OAuth consent is semantically a new approval, not a patch.

## TDD

One failing integration test in `v300_oauth_as.rs` runs the full authorize→consent flow and asserts the new event_type, resource shape, and scopes payload. Full integration suite: **1195 tests pass** (up from 1194). Clippy clean (only pre-existing `PolicyEngine` unused-import warnings in unrelated tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)