### PR TITLE
fix(mcp): emit McpServerChanged on workspace binding add/remove (#32)

### DIFF
--- a/crates/server/src/routes/admin_api/mcp_servers/bindings.rs
+++ b/crates/server/src/routes/admin_api/mcp_servers/bindings.rs
@@ -11,6 +11,7 @@ use agent_cordon_core::domain::mcp::McpServerId;
 use agent_cordon_core::domain::user::UserRole;
 use agent_cordon_core::domain::workspace::{Workspace, WorkspaceId};
 
+use crate::events::UiEvent;
 use crate::extractors::AuthenticatedUser;
 use crate::middleware::request_id::CorrelationId;
 use crate::response::{ApiError, ApiResponse};
@@ -131,6 +132,14 @@ pub(super) async fn add_workspace_bindings(
         StatusCode::CREATED
     };
 
+    // Issue #32 — notify the MCP servers list page so its Workspaces column
+    // refreshes after a binding mutation.
+    if !added.is_empty() {
+        state.ui_event_bus.emit(UiEvent::McpServerChanged {
+            server_name: server.name.clone(),
+        });
+    }
+
     Ok((
         status,
         Json(ApiResponse::ok(AddWorkspaceBindingsData {
@@ -227,6 +236,12 @@ pub(super) async fn remove_workspace_binding(
     if let Err(e) = state.store.append_audit_event(&event).await {
         tracing::warn!(error = %e, "Failed to write audit event");
     }
+
+    // Issue #32 — notify the MCP servers list page so its Workspaces column
+    // refreshes after a binding mutation.
+    state.ui_event_bus.emit(UiEvent::McpServerChanged {
+        server_name: server.name.clone(),
+    });
 
     Ok(StatusCode::NO_CONTENT)
 }

--- a/crates/server/tests/v313_mcp_server_workspaces.rs
+++ b/crates/server/tests/v313_mcp_server_workspaces.rs
@@ -1197,3 +1197,81 @@ async fn case_6_2_workspace_list_admin_sees_all() {
         ids
     );
 }
+
+// ===========================================================================
+// Issue #32 — POST/DELETE on /mcp-servers/{id}/workspaces must emit
+// UiEvent::McpServerChanged so the list page's Workspaces column refreshes.
+// ===========================================================================
+
+/// #32 — RED: add_workspace_bindings emits a UI event after a successful add.
+#[tokio::test]
+async fn add_workspace_bindings_emits_ui_event() {
+    let ctx = TestAppBuilder::new().build().await;
+    let _admin = make_admin(&ctx, "admin-32a").await;
+    let (admin_cookie, admin_csrf) = login(&ctx, "admin-32a").await;
+    let fx = owner_fixture(&ctx, "ev-add").await;
+    let ws_b = make_owned_workspace(&ctx, "ws-b-add-32", &fx.owner).await;
+
+    let mut rx = ctx.state.ui_event_bus.subscribe();
+
+    let (status, _body) = post_bindings(
+        &ctx,
+        &admin_cookie,
+        &admin_csrf,
+        &fx.mcp.id,
+        json!({ "workspace_ids": [ws_b.id.0.to_string()] }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED);
+
+    let ev = tokio::time::timeout(std::time::Duration::from_millis(500), rx.recv())
+        .await
+        .expect("ui event must be emitted within 500ms")
+        .expect("ui event must be received without channel error");
+    assert!(
+        matches!(
+            ev,
+            agent_cordon_server::events::UiEvent::McpServerChanged { .. }
+        ),
+        "expected McpServerChanged, got {ev:?}",
+    );
+}
+
+/// #32 — RED: remove_workspace_binding emits a UI event after a successful remove.
+#[tokio::test]
+async fn remove_workspace_binding_emits_ui_event() {
+    let ctx = TestAppBuilder::new().build().await;
+    let _admin = make_admin(&ctx, "admin-32b").await;
+    let (admin_cookie, admin_csrf) = login(&ctx, "admin-32b").await;
+    let fx = owner_fixture(&ctx, "ev-rm").await;
+    let ws_b = make_owned_workspace(&ctx, "ws-b-rm-32", &fx.owner).await;
+
+    // Bind first so there are 2 workspaces — the last-binding guard prevents
+    // removing the only one. Drain the add event before subscribing for the
+    // remove.
+    let (status, _) = post_bindings(
+        &ctx,
+        &admin_cookie,
+        &admin_csrf,
+        &fx.mcp.id,
+        json!({ "workspace_ids": [ws_b.id.0.to_string()] }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED);
+
+    let mut rx = ctx.state.ui_event_bus.subscribe();
+    let (status, _) = delete_binding(&ctx, &admin_cookie, &admin_csrf, &fx.mcp.id, &ws_b.id).await;
+    assert_eq!(status, StatusCode::NO_CONTENT);
+
+    let ev = tokio::time::timeout(std::time::Duration::from_millis(500), rx.recv())
+        .await
+        .expect("ui event must be emitted within 500ms")
+        .expect("ui event must be received without channel error");
+    assert!(
+        matches!(
+            ev,
+            agent_cordon_server::events::UiEvent::McpServerChanged { .. }
+        ),
+        "expected McpServerChanged, got {ev:?}",
+    );
+}


### PR DESCRIPTION
Closes #32.

## Root cause

The two endpoints that mutate the `mcp_server_workspaces` junction were the **only** mutations in `crates/server/src/routes/admin_api/mcp_servers/` that didn't emit `UiEvent::McpServerChanged`:

- `POST   /api/v1/mcp-servers/{id}/workspaces`
- `DELETE /api/v1/mcp-servers/{id}/workspaces/{workspace_id}`

The MCP servers list page subscribes to `ac:mcp_server_changed` and reloads on every event. With these emits missing, the **Workspaces column stayed stale** until a manual refresh.

## Fix

Add emits matching the shape used everywhere else in the module: `UiEvent::McpServerChanged { server_name }`. The add path only emits when something was actually added (so a re-bind of an already-bound workspace, which returns 200 with `added: []`, stays silent — no spurious refresh).

## TDD

Two new integration tests in `v313_mcp_server_workspaces.rs`:
- `add_workspace_bindings_emits_ui_event` — RED with the bug, GREEN after fix
- `remove_workspace_binding_emits_ui_event` — RED with the bug, GREEN after fix

Both subscribe to `state.ui_event_bus`, drive the route through the real router, and assert a `McpServerChanged` event arrives within 500ms. Full suite: **1197 tests pass** (up from 1195).

🤖 Generated with [Claude Code](https://claude.com/claude-code)