### PR TITLE
fix(audit): surface credential name + icon on unexpanded row

### DIFF
--- a/crates/server/src/routes/admin_ui/pages/audit.rs
+++ b/crates/server/src/routes/admin_ui/pages/audit.rs
@@ -34,6 +34,107 @@ pub struct AuditEventView {
     pub decision_reason: String,
     pub metadata_json: String,
     pub summary: String,
+    /// Icon hint for the unexpanded row (e.g. "credential" for credential
+    /// lifecycle events). Empty when no icon should be shown.
+    pub icon: String,
+}
+
+impl AuditEventView {
+    pub fn from_event(ev: &agent_cordon_core::domain::audit::AuditEvent) -> Self {
+        use agent_cordon_core::domain::audit::AuditEventType;
+
+        let decision_str = match &ev.decision {
+            AuditDecision::Permit => "permit",
+            AuditDecision::Forbid => "forbid",
+            AuditDecision::Error => "error",
+            AuditDecision::NotApplicable => "n/a",
+        };
+        let decision_class = match &ev.decision {
+            AuditDecision::Permit => "pill-ok",
+            AuditDecision::Forbid => "pill-bad",
+            _ => "pill-warn",
+        };
+        let principal = ev
+            .workspace_name
+            .as_deref()
+            .or(ev.user_name.as_deref())
+            .unwrap_or("\u{2014}")
+            .to_string();
+        let resource_id_short = ev
+            .resource_id
+            .as_ref()
+            .map(|rid| {
+                if rid.len() > 8 {
+                    format!("{}...", &rid[..8])
+                } else {
+                    rid.clone()
+                }
+            })
+            .unwrap_or_default();
+        let event_type_str = serde_json::to_string(&ev.event_type)
+            .unwrap_or_else(|_| format!("{:?}", ev.event_type))
+            .trim_matches('"')
+            .to_string();
+
+        let icon = if matches!(
+            ev.event_type,
+            AuditEventType::CredentialCreated
+                | AuditEventType::CredentialUpdated
+                | AuditEventType::CredentialDeleted
+                | AuditEventType::CredentialAccessRequested
+                | AuditEventType::CredentialAccessGranted
+                | AuditEventType::CredentialAccessDenied
+                | AuditEventType::CredentialExpired
+                | AuditEventType::CredentialLeakDetected
+                | AuditEventType::CredentialSecretViewed
+                | AuditEventType::CredentialSecretRotated
+                | AuditEventType::CredentialSecretRestored
+                | AuditEventType::CredentialVended
+                | AuditEventType::CredentialVendDenied
+                | AuditEventType::CredentialStored
+                | AuditEventType::CredentialScopeCheck
+                | AuditEventType::CredentialProxyAuth
+        ) {
+            "credential".to_string()
+        } else {
+            String::new()
+        };
+
+        Self {
+            id: ev.id.to_string(),
+            timestamp: ev.timestamp.to_rfc3339(),
+            event_type: event_type_str,
+            principal,
+            action: ev.action.clone(),
+            resource_type: ev.resource_type.clone(),
+            resource_id: ev.resource_id.clone().unwrap_or_default(),
+            resource_id_short,
+            decision: decision_str.to_string(),
+            decision_class: decision_class.to_string(),
+            correlation_id: ev.correlation_id.clone(),
+            decision_reason: ev.decision_reason.clone().unwrap_or_default(),
+            metadata_json: serde_json::to_string_pretty(&ev.metadata)
+                .unwrap_or_else(|_| "{}".to_string()),
+            summary: extract_audit_summary(&ev.metadata),
+            icon,
+        }
+    }
+}
+
+/// Extract the most important detail from audit event metadata for inline display.
+fn extract_audit_summary(metadata: &serde_json::Value) -> String {
+    for key in [
+        "credential_name",
+        "tool",
+        "tool_name",
+        "name",
+        "resource_name",
+    ] {
+        if let Some(v) = metadata.get(key).and_then(|v| v.as_str()) {
+            return v.to_string();
+        }
+    }
+    String::new()
 }
 
 // ---------------------------------------------------------------------------
@@ -123,85 +224,7 @@ pub async fn audit_page(State(state): State<AppState>, request: Request) -> Resp
         events
     };
 
-    let event_views: Vec<AuditEventView> = events
-        .iter()
-        .map(|ev| {
-            let decision_str = match &ev.decision {
-                AuditDecision::Permit => "permit",
-                AuditDecision::Forbid => "forbid",
-                AuditDecision::Error => "error",
-                AuditDecision::NotApplicable => "n/a",
-            };
-            let decision_class = match &ev.decision {
-                AuditDecision::Permit => "pill-ok",
-                AuditDecision::Forbid => "pill-bad",
-                _ => "pill-warn",
-            };
-            let principal = ev
-                .workspace_name
-                .as_deref()
-                .or(ev.user_name.as_deref())
-                .unwrap_or("\u{2014}")
-                .to_string();
-            let resource_id_short = ev
-                .resource_id
-                .as_ref()
-                .map(|rid| {
-                    if rid.len() > 8 {
-                        format!("{}...", &rid[..8])
-                    } else {
-                        rid.clone()
-                    }
-                })
-                .unwrap_or_default();
-
-            let summary = extract_audit_summary(&ev.metadata);
-
-            // Use serde snake_case for event_type to match the API format
-            let event_type_str = serde_json::to_string(&ev.event_type)
-                .unwrap_or_else(|_| format!("{:?}", ev.event_type))
-                .trim_matches('"')
-                .to_string();
-
-            AuditEventView {
-                id: ev.id.to_string(),
-                timestamp: ev.timestamp.to_rfc3339(),
-                event_type: event_type_str,
-                principal,
-                action: ev.action.clone(),
-                resource_type: ev.resource_type.clone(),
-                resource_id: ev.resource_id.clone().unwrap_or_default(),
-                resource_id_short,
-                decision: decision_str.to_string(),
-                decision_class: decision_class.to_string(),
-                correlation_id: ev.correlation_id.clone(),
-                decision_reason: ev.decision_reason.clone().unwrap_or_default(),
-                metadata_json: serde_json::to_string_pretty(&ev.metadata)
-                    .unwrap_or_else(|_| "{}".to_string()),
-                summary,
-            }
-        })
-        .collect();
-
-    /// Extract the most important detail from audit event metadata for inline display.
-    fn extract_audit_summary(metadata: &serde_json::Value) -> String {
-        if let Some(v) = metadata.get("credential_name").and_then(|v| v.as_str()) {
-            return v.to_string();
-        }
-        if let Some(v) = metadata.get("tool").and_then(|v| v.as_str()) {
-            return v.to_string();
-        }
-        if let Some(v) = metadata.get("tool_name").and_then(|v| v.as_str()) {
-            return v.to_string();
-        }
-        if let Some(v) = metadata.get("name").and_then(|v| v.as_str()) {
-            return v.to_string();
-        }
-        if let Some(v) = metadata.get("resource_name").and_then(|v| v.as_str()) {
-            return v.to_string();
-        }
-        String::new()
-    }
+    let event_views: Vec<AuditEventView> = events.iter().map(AuditEventView::from_event).collect();
 
     let events_json = serde_json::to_string(&event_views)
         .unwrap_or_else(|_| "[]".to_string())
@@ -215,6 +238,41 @@ pub async fn audit_page(State(state): State<AppState>, request: Request) -> Resp
         events: event_views,
         events_json,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use agent_cordon_core::domain::audit::{AuditEvent, AuditEventType};
+    use agent_cordon_core::domain::workspace::WorkspaceId;
+
+    #[test]
+    fn credential_vended_event_view_has_credential_icon_and_name_and_workspace() {
+        let event = AuditEvent::builder(AuditEventType::CredentialVended)
+            .action("vend")
+            .resource("credential", "cred-1")
+            .workspace_actor(&WorkspaceId(Uuid::new_v4()), "ws-a")
+            .details(serde_json::json!({ "credential_name": "cred-1" }))
+            .build();
+
+        let view = AuditEventView::from_event(&event);
+
+        assert_eq!(view.icon, "credential");
+        assert_eq!(view.summary, "cred-1");
+        assert_eq!(view.principal, "ws-a");
+    }
+
+    #[test]
+    fn non_credential_event_view_has_no_icon() {
+        let event = AuditEvent::builder(AuditEventType::PolicyEvaluated)
+            .action("evaluate")
+            .resource_type("policy")
+            .build();
+
+        let view = AuditEventView::from_event(&event);
+
+        assert_eq!(view.icon, "");
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/server/templates/pages/audit.html
+++ b/crates/server/templates/pages/audit.html
@@ -84,6 +84,12 @@
                         <span class="audit-timestamp" :title="formatDateTime(ev.timestamp)" x-text="timeAgo(ev.timestamp)"></span>
                     </td>
                     <td class="audit-col-type">
+                        <svg x-show="ev.icon === 'credential'"
+                             class="audit-evt-icon audit-evt-icon-credential"
+                             width="14" height="14" viewBox="0 0 24 24" fill="none"
+                             stroke="currentColor" stroke-width="1.75"
+                             stroke-linecap="round" stroke-linejoin="round"
+                             aria-hidden="true"><circle cx="8" cy="15" r="4"/><line x1="10.85" y1="12.15" x2="19" y2="4"/><line x1="18" y1="5" x2="20" y2="7"/><line x1="15" y1="8" x2="17" y2="10"/></svg>
                         <span class="pill pill-type" x-text="humanEventType(ev.event_type)"></span>
                     </td>
                     <td class="audit-col-principal" x-text="ev.principal"></td>
@@ -92,7 +98,9 @@
                         <span x-show="ev.resource_id_short"
                               class="mono-sm audit-resource-id"
                               x-text="ev.resource_id_short"></span>
-                        <span x-show="ev.summary" class="audit-summary-pill" x-text="ev.summary"></span>
+                        <span x-show="ev.summary"
+                              :class="ev.icon === 'credential' ? 'audit-cred-name' : 'audit-summary-pill'"
+                              x-text="ev.summary"></span>
                     </td>
                     <td class="audit-col-decision">
                         <span class="pill" :class="ev.decision_class" x-text="ev.decision"></span>
@@ -465,6 +473,13 @@ function auditListPage() {
 
 /* Resource ID */
 .audit-resource-id { color: var(--ink-faint); margin-left: 4px; }
+
+/* Event-type icon (e.g. credential glyph for credential lifecycle events) */
+.audit-evt-icon { color: var(--ink-soft); vertical-align: -2px; margin-right: 4px; }
+
+/* Credential name on credential-lifecycle rows — more prominent than the
+   faint audit-summary-pill used for other metadata previews. */
+.audit-cred-name { font-family: var(--font-mono); font-size: 12px; color: var(--ink); margin-left: 6px; }
 
 /* Chevron toggle */
 .audit-chevron { transition: transform 0.15s ease; color: var(--ink-faint); }

--- a/crates/server/tests/main.rs
+++ b/crates/server/tests/main.rs
@@ -62,6 +62,7 @@ mod v1150_credential_history_ui;
 mod v1150_migration_consolidation;
 mod v1150_nonce_tracking;
 mod v1150_workspace_identity_tag;
+mod v1160_audit_credential_icon;
 mod v153_openapi;
 mod v153_server_defaults;
 mod v154_e2e;

--- a/crates/server/tests/v1160_audit_credential_icon.rs
+++ b/crates/server/tests/v1160_audit_credential_icon.rs
@@ -1,0 +1,117 @@
+//! Integration tests — issue #35: audit log credential-icon row hint.
+//!
+//! Verifies that credential lifecycle events render an icon hint
+//! (`icon == "credential"`) in the audit page's embedded events array,
+//! so the unexpanded row can show a credential glyph alongside the
+//! credential name and workspace.
+
+use axum::body::Body;
+use axum::http::{header, Method, Request, StatusCode};
+use http_body_util::BodyExt;
+use serde_json::json;
+use tower::ServiceExt;
+
+use agent_cordon_core::domain::audit::{AuditDecision, AuditEvent, AuditEventType};
+use agent_cordon_core::domain::user::UserRole;
+use agent_cordon_core::domain::workspace::WorkspaceId;
+use agent_cordon_core::storage::Store;
+use agent_cordon_server::test_helpers::TestAppBuilder;
+use uuid::Uuid;
+
+use crate::common;
+
+async fn seed_credential_vended_event(store: &(dyn Store + Send + Sync)) {
+    let event = AuditEvent::builder(AuditEventType::CredentialVended)
+        .action("vend_credential")
+        .resource("credential", "cred-xyz")
+        .workspace_actor(&WorkspaceId(Uuid::new_v4()), "ws-alpha")
+        .details(json!({ "credential_name": "github-token" }))
+        .decision(AuditDecision::Permit, None)
+        .build();
+    store
+        .append_audit_event(&event)
+        .await
+        .expect("seed credential vended event");
+}
+
+async fn get_page(app: &axum::Router, uri: &str, cookie: &str) -> (StatusCode, String) {
+    let resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method(Method::GET)
+                .uri(uri)
+                .header(header::COOKIE, cookie)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let status = resp.status();
+    let body = String::from_utf8(
+        resp.into_body()
+            .collect()
+            .await
+            .unwrap()
+            .to_bytes()
+            .to_vec(),
+    )
+    .unwrap();
+    (status, body)
+}
+
+#[tokio::test]
+async fn audit_page_template_renders_credential_icon_svg() {
+    let ctx = TestAppBuilder::new().with_admin().build().await;
+    let _admin = common::create_test_user(
+        &*ctx.store,
+        "icon-admin-2",
+        common::TEST_PASSWORD,
+        UserRole::Admin,
+    )
+    .await;
+    let cookie = common::login_user_combined(&ctx.app, "icon-admin-2", common::TEST_PASSWORD).await;
+
+    let (status, body) = get_page(&ctx.app, "/audit", &cookie).await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert!(
+        body.contains("audit-evt-icon-credential"),
+        "audit page template should render a credential icon marker so the unexpanded row shows a glyph for credential events"
+    );
+    assert!(
+        body.contains("ev.icon === 'credential'"),
+        "the credential icon should be conditionally shown via ev.icon"
+    );
+}
+
+#[tokio::test]
+async fn audit_page_emits_credential_icon_hint_for_vending_row() {
+    let ctx = TestAppBuilder::new().with_admin().build().await;
+    let _admin = common::create_test_user(
+        &*ctx.store,
+        "icon-admin",
+        common::TEST_PASSWORD,
+        UserRole::Admin,
+    )
+    .await;
+    let cookie = common::login_user_combined(&ctx.app, "icon-admin", common::TEST_PASSWORD).await;
+
+    seed_credential_vended_event(&*ctx.store).await;
+
+    let (status, body) = get_page(&ctx.app, "/audit", &cookie).await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert!(
+        body.contains("\"icon\":\"credential\""),
+        "audit page should embed icon hint for credential events; body did not contain it"
+    );
+    assert!(
+        body.contains("github-token"),
+        "audit page should embed the credential name"
+    );
+    assert!(
+        body.contains("ws-alpha"),
+        "audit page should embed the workspace name"
+    );
+}


### PR DESCRIPTION
## Summary
- Adds an `icon` hint to `AuditEventView` and renders an inline credential SVG on the unexpanded audit row for every credential lifecycle event (vended, vend-denied, access granted/denied, secret viewed/rotated, etc.).
- Promotes the credential name from the faint `audit-summary-pill` to a more readable inline label on credential rows. Workspace remains visible via the existing Principal column.
- Refactors the inline view-model assembly in `audit_page` into a pure `AuditEventView::from_event` constructor so the row data is unit-testable.

Closes #35

## Test plan
- [x] Unit: `credential_vended_event_view_has_credential_icon_and_name_and_workspace` — view model carries `icon == "credential"`, `summary == <credential_name>`, `principal == <workspace_name>`.
- [x] Unit: `non_credential_event_view_has_no_icon` — non-credential events get no icon hint.
- [x] Integration: `audit_page_emits_credential_icon_hint_for_vending_row` — rendered `/audit` body contains the icon hint, credential name, and workspace name for a seeded `CredentialVended` event.
- [x] Integration: `audit_page_template_renders_credential_icon_svg` — rendered body contains the `audit-evt-icon-credential` SVG marker wired to `ev.icon === 'credential'`.
- [x] All 86 existing audit-related tests still pass after the view-model refactor.
- [ ] Visual: hit `/audit` in the dev UI and confirm the credential glyph sits left of the event-type pill and the credential name reads cleanly.