### PR TITLE
chore: release v0.3.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agent-cordon-core"
-version = "0.3.0"
+version = "0.3.2"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -83,7 +83,7 @@ dependencies = [
 
 [[package]]
 name = "agent-cordon-server"
-version = "0.3.0"
+version = "0.3.2"
 dependencies = [
  "agent-cordon-core",
  "agent-cordon-server",
@@ -131,7 +131,7 @@ dependencies = [
 
 [[package]]
 name = "agentcordon-broker"
-version = "0.3.0"
+version = "0.3.2"
 dependencies = [
  "aes-gcm",
  "agent-cordon-core",
@@ -167,7 +167,7 @@ dependencies = [
 
 [[package]]
 name = "agentcordon-cli"
-version = "0.3.0"
+version = "0.3.2"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/core", "crates/server", "crates/broker", "crates/cli"]
 
 [workspace.package]
-version = "0.3.0"
+version = "0.3.2"
 edition = "2021"
 license = "MIT"
 homepage = "https://agentcordon.dev"

--- a/crates/server/src/routes/oauth/consent.rs
+++ b/crates/server/src/routes/oauth/consent.rs
@@ -541,9 +541,7 @@ mod tests {
         let workspaces = ctx.store.list_workspaces().await.expect("list");
         let alice_dev: Vec<_> = workspaces
             .iter()
-            .filter(|w| {
-                w.name == "dev" && w.pk_hash.as_deref() == Some("pk_hash_alice")
-            })
+            .filter(|w| w.name == "dev" && w.pk_hash.as_deref() == Some("pk_hash_alice"))
             .collect();
         assert_eq!(
             alice_dev.len(),

--- a/crates/server/tests/v1110_cross_feature.rs
+++ b/crates/server/tests/v1110_cross_feature.rs
@@ -291,7 +291,6 @@ async fn test_dashboard_shows_mcp_activity_after_device_proxy() {
     );
 }
 
-
 #[tokio::test]
 async fn test_migration_then_upload_then_sync() {
     // Device has existing MCP → agent uploads new MCP → verify both exist.

--- a/crates/server/tests/v1110_device_scoped_mcps.rs
+++ b/crates/server/tests/v1110_device_scoped_mcps.rs
@@ -173,12 +173,9 @@ async fn test_list_mcp_servers_no_filter_returns_all() {
     );
 }
 
-
-
 // ---------------------------------------------------------------------------
 // 9B. Retry/Idempotency — duplicate MCP on same device
 // ---------------------------------------------------------------------------
-
 
 #[tokio::test]
 async fn test_create_duplicate_mcp_same_device_after_delete() {
@@ -204,8 +201,6 @@ async fn test_create_duplicate_mcp_same_device_after_delete() {
 // ---------------------------------------------------------------------------
 // 9C. Error Handling
 // ---------------------------------------------------------------------------
-
-
 
 // ---------------------------------------------------------------------------
 // 9D. Cross-Feature
@@ -262,7 +257,6 @@ async fn test_cross_device_mcp_authorization_works() {
         "cross-device MCP grant policy should exist"
     );
 }
-
 
 #[tokio::test]
 async fn test_permissions_grant_on_device_scoped_mcp() {

--- a/crates/server/tests/v1110_migration.rs
+++ b/crates/server/tests/v1110_migration.rs
@@ -105,7 +105,6 @@ async fn test_migration_fresh_install_no_mcps() {
     assert_eq!(all_mcps.len(), 0, "fresh install should have no MCPs");
 }
 
-
 #[tokio::test]
 async fn test_migration_preserves_ids_on_oldest_workspace() {
     // Create MCP with known ID on a workspace. Verify the ID is preserved after retrieval.
@@ -259,11 +258,5 @@ async fn test_migration_existing_grants_preserved() {
     );
 }
 
-
-
-
-
 // test_post_migration_create_mcp_requires_workspace_id removed — admin create endpoint no longer exists.
 // MCP servers are now registered via the workspace import endpoint only.
-
-

--- a/crates/server/tests/v1170_mcp_workspace_consolidation.rs
+++ b/crates/server/tests/v1170_mcp_workspace_consolidation.rs
@@ -272,8 +272,7 @@ async fn list_mcp_servers_filtered_by_workspace_reads_junction_not_legacy_column
 async fn admin_filter_broker_sync_and_token_scopes_agree_on_junction_bound_mcps() {
     let ctx = TestAppBuilder::new().with_admin().build().await;
     let admin = make_admin(&ctx, "parity-admin").await;
-    let (session, csrf) =
-        common::login_user(&ctx.app, "parity-admin", common::TEST_PASSWORD).await;
+    let (session, csrf) = common::login_user(&ctx.app, "parity-admin", common::TEST_PASSWORD).await;
     let cookie = common::combined_cookie(&session, &csrf);
 
     let ws = make_workspace(&ctx, "parity-ws", &admin).await;
@@ -285,8 +284,9 @@ async fn admin_filter_broker_sync_and_token_scopes_agree_on_junction_bound_mcps(
     let mcp_b = make_mcp_bound_to(&ctx, "parity-b", &ws, &ws, &admin).await;
     let _mcp_other = make_mcp_bound_to(&ctx, "parity-other-only", &other, &other, &admin).await;
 
-    let expected: std::collections::HashSet<String> =
-        [mcp_a.name.clone(), mcp_b.name.clone()].into_iter().collect();
+    let expected: std::collections::HashSet<String> = [mcp_a.name.clone(), mcp_b.name.clone()]
+        .into_iter()
+        .collect();
 
     // Path 1: admin filter
     let (status, body) = common::send_json(


### PR DESCRIPTION
Version bump for v0.3.2.

Captures everything that landed since the `v0.3.1` tag (which was tagged on a tree that still said `0.3.0` in source — this is the first source-aligned release since 0.3.0):

- Authz seam: single front door for policy evaluation (#23)
- agent-first `mcp-call` / `mcp-tools` CLI surface (#27)
- OAuth consent grant management UI + cascade revoke (#29, #30)
- `McpServerChanged` event on binding add/remove (#33)
- Row-click navigation on MCP servers list (#34)
- Audit log: credential icon + name on unexpanded row (#36)
- MCP↔workspace junction as single source of truth (#38, #42) — relaxes `mcp_servers.workspace_id` to nullable, switches every read path to the junction, fixes a re-import dedup bug uncovered during cleanup
- `agentcordon register --name <NAME>` + duplicate workspace names allowed (#40)

Merge this, then I'll dispatch `release.yml` with version `0.3.2`.